### PR TITLE
Removed trailling separator in author list

### DIFF
--- a/blog/.vuepress/components/preview.vue
+++ b/blog/.vuepress/components/preview.vue
@@ -12,7 +12,6 @@
         <div>{{meetup.old.location}}</div>
         <span v-for="(s, i) in speakers" :key="i" class="Preview-author">
           <a :href="s.profile" target="_blank">{{s.author}}</a>
-          <span class="Author-separator">|</span>
         </span>
       </div>
     </div>
@@ -72,7 +71,8 @@ export default {
   margin-right: 40px;
 }
 
-.Author-separator {
+.Preview-author + .Preview-author:before {
+  content: "|";
   margin-right: 10px;
   margin-left: 10px;
 }


### PR DESCRIPTION
Small PR to improve the tags page:

![image](https://user-images.githubusercontent.com/5289520/63938305-7d3f8080-ca32-11e9-9474-f44904cad2c1.png)

Removing the trailling separators:

![image](https://user-images.githubusercontent.com/5289520/63938268-6731c000-ca32-11e9-9ce2-d98f21b3aae4.png)
