### PR TITLE
Changed default browser tab name from VuePress to VueMtl

### DIFF
--- a/blog/.vuepress/config.js
+++ b/blog/.vuepress/config.js
@@ -38,7 +38,7 @@ module.exports = {
       }
     ]
   },
-  title: "",
+  title: "VueMtl",
   head: [
     [
       "link",


### PR DESCRIPTION
Since the deployed app is showing the default VuePress name on the browser tab, I changed it with VueMtl to reflect the real name.