### PR TITLE
chore: clean up eslint rules 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,10 +17,10 @@ module.exports = {
   plugins: [
     'prettier'
   ],
-  // add your custom rules here
   rules: {
-    "prettier/prettier": ["error", {
-     "endOfLine":"auto"
+    'no-console': ['error', { 'allow': ['warn', 'error'] }],
+    'prettier/prettier': ['error', {
+     'endOfLine':'lf'
    }],
   }
 }

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,5 +1,6 @@
 {
   "semi": false,
+  "endOfLine": "lf",
   "arrowParens": "always",
   "singleQuote": true
 }

--- a/components/navbar/navbar-top.vue
+++ b/components/navbar/navbar-top.vue
@@ -49,7 +49,7 @@
         placeholder="search"
       />
       <button
-        v-if="search"
+        v-show="search"
         @click="clearSearch"
         type="button"
         class="close-icon"
@@ -78,14 +78,8 @@ export default {
     }
   },
 
-  watch: {
-    '$route.query': {
-      handler() {
-        const { searchTerm = '' } = this.$route.query
-        this.search = searchTerm
-      },
-      immediate: true
-    }
+  created() {
+    this.search = this.$route.query.searchTerm
   },
 
   methods: {

--- a/components/navbar/navbar-top.vue
+++ b/components/navbar/navbar-top.vue
@@ -93,7 +93,6 @@ export default {
       this.search = ''
       const query = Object.assign({}, this.$route.query)
       delete query.searchTerm
-      console.log(query)
       this.$router.replace({ query })
     },
 

--- a/components/navbar/navbar-top.vue
+++ b/components/navbar/navbar-top.vue
@@ -79,13 +79,13 @@ export default {
   },
   methods: {
     submitSearch() {
-      const { with_tag } = this.$route.query
+      const { withTag } = this.$route.query
       const lang = this.$store.state.i18n.locale
 
       const query = {
-        search_term: this.search
+        searchTerm: this.search
       }
-      if (with_tag) query.with_tag = with_tag
+      if (withTag) query.withTag = withTag
 
       this.$router.push({
         path: '/' + lang + '/search',

--- a/components/navbar/navbar-top.vue
+++ b/components/navbar/navbar-top.vue
@@ -50,7 +50,7 @@
       />
       <button
         v-if="search.length"
-        @click="search = ''"
+        @click="clearSearch"
         type="button"
         class="close-icon"
       >
@@ -89,6 +89,14 @@ export default {
   },
 
   methods: {
+    clearSearch() {
+      this.search = ''
+      const query = Object.assign({}, this.$route.query)
+      delete query.searchTerm
+      console.log(query)
+      this.$router.replace({ query })
+    },
+
     submitSearch() {
       const { withTag } = this.$route.query
       const lang = this.$store.state.i18n.locale
@@ -103,6 +111,7 @@ export default {
         query
       })
     },
+
     openNav() {
       this.$store.commit('openNavMobile')
     }

--- a/components/navbar/navbar-top.vue
+++ b/components/navbar/navbar-top.vue
@@ -49,7 +49,7 @@
         placeholder="search"
       />
       <button
-        v-if="search.length"
+        v-if="search"
         @click="clearSearch"
         type="button"
         class="close-icon"
@@ -92,8 +92,10 @@ export default {
     clearSearch() {
       this.search = ''
       const query = Object.assign({}, this.$route.query)
+      if (!query.searchTerm) return
+
       delete query.searchTerm
-      this.$router.replace({ query })
+      this.$router.push({ query })
     },
 
     submitSearch() {

--- a/components/navbar/navbar-top.vue
+++ b/components/navbar/navbar-top.vue
@@ -77,6 +77,17 @@ export default {
       search: ''
     }
   },
+
+  watch: {
+    '$route.query': {
+      handler() {
+        const { searchTerm = '' } = this.$route.query
+        this.search = searchTerm
+      },
+      immediate: true
+    }
+  },
+
   methods: {
     submitSearch() {
       const { withTag } = this.$route.query

--- a/components/navbar/navbar-top.vue
+++ b/components/navbar/navbar-top.vue
@@ -70,8 +70,6 @@
 </template>
 
 <script>
-/* eslint-disable camelcase */
-
 export default {
   name: 'NavBarTop',
   data() {
@@ -81,10 +79,7 @@ export default {
   },
   methods: {
     submitSearch() {
-      const {
-        // types = ['events'],
-        with_tag
-      } = this.$route.query
+      const { with_tag } = this.$route.query
       const lang = this.$store.state.i18n.locale
 
       const query = {

--- a/configs/buildModules.js
+++ b/configs/buildModules.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 require('dotenv').config()
 
 module.exports = [
@@ -11,4 +9,4 @@ module.exports = [
       id: process.env.GOOGLE_ANALYTIC
     }
   ]
-];
+]

--- a/configs/generate.js
+++ b/configs/generate.js
@@ -26,7 +26,6 @@ const generateStoryblokEventRoutes = async () => {
 
     return ret
   } catch (e) {
-    // eslint-disable-next-line no-console
     console.error(e)
   }
 }

--- a/configs/generate.js
+++ b/configs/generate.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 require('dotenv').config()
 const axios = require('axios')
 
@@ -28,18 +26,17 @@ const generateStoryblokEventRoutes = async () => {
 
     return ret
   } catch (e) {
+    // eslint-disable-next-line no-console
     console.error(e)
   }
 }
-
 
 module.exports = {
   generate: {
     routes: generateStoryblokEventRoutes
   },
-  sitemap:{
+  sitemap: {
     hostname: 'https://vuemontreal.org',
     routes: generateStoryblokEventRoutes
   }
 }
-

--- a/configs/i18n.js
+++ b/configs/i18n.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 require('dotenv').config()
 
 module.exports = {

--- a/configs/modules.js
+++ b/configs/modules.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 require('dotenv').config()
 
 module.exports = [
@@ -30,5 +28,5 @@ module.exports = [
     }
   ],
   'nuxt-i18n',
-  '@nuxtjs/sitemap',
+  '@nuxtjs/sitemap'
 ]

--- a/configs/server.js
+++ b/configs/server.js
@@ -1,5 +1,3 @@
-/* eslint-disable */
-
 require('dotenv').config()
 
 module.exports = {

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -1,12 +1,9 @@
-/* eslint-disable */
-
 require('dotenv').config()
-
 
 export default {
   mode: 'universal',
   env: {
-    version: process.env.STORYBLOK_VERSION || 'draft',
+    version: process.env.STORYBLOK_VERSION || 'draft'
   },
   head: require('./configs/head'),
   server: require('./configs/server'),
@@ -14,5 +11,5 @@ export default {
   modules: require('./configs/modules'),
   generate: require('./configs/generate').generate,
   sitemap: require('./configs/generate').sitemap,
-  i18n: require('./configs/i18n'),
+  i18n: require('./configs/i18n')
 }

--- a/pages/events/_eventId.vue
+++ b/pages/events/_eventId.vue
@@ -101,7 +101,6 @@ export default {
     }
   },
   async fetch() {
-    /* eslint-disable nuxt/no-this-in-fetch-data */
     const eventId = this.$route.params.eventId
     const locale = this.$i18n.locale
 

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -58,7 +58,7 @@ export default {
     '$route.query': '$fetch'
   },
   async fetch() {
-    const { with_tag = '', search_term = '' } = this.$route.query
+    const { withTag = '', searchTerm = '' } = this.$route.query
     const lang = this.$store.state.i18n.locale
 
     const { version } = this.$nuxt.context.env
@@ -69,14 +69,14 @@ export default {
         starts_with: 'events/'
       })
       this.possibleTags = [...dataTags.data.tags]
-      this.checkedTags = this.parseUrlTags(with_tag)
+      this.checkedTags = this.parseUrlTags(withTag)
 
       const events = await this.$storyapi.get('cdn/stories/', {
         version,
         starts_with: lang + '/events/',
         sort_by: 'sort_by_date:desc',
-        with_tag: this.checkedTags,
-        search_term
+        withTag: this.checkedTags,
+        searchTerm
       })
       this.events = events.data.stories
     } catch (e) {
@@ -92,16 +92,16 @@ export default {
       return !!this.possibleTags.find((p) => p.name === tag)
     },
     // get tags from url and parse it without adding bad tags
-    parseUrlTags(with_tag) {
+    parseUrlTags(withTag) {
       const tmp = []
-      const splitTags = with_tag.split(',')
+      const splitTags = withTag.split(',')
       splitTags.forEach((tag) => (this.isValid(tag) ? tmp.push(tag) : ''))
       return tmp
     },
     checked(val, checked) {
-      const { search_term = '', with_tag = '' } = this.$route.query
+      const { searchTerm = '', withTag = '' } = this.$route.query
 
-      let tags = this.parseUrlTags(with_tag)
+      let tags = this.parseUrlTags(withTag)
 
       if (checked && this.isValid(val)) {
         tags.push(val)
@@ -116,8 +116,8 @@ export default {
       this.$router.push({
         path: this.switchLocalePath('/search'),
         query: {
-          with_tag: tags.join(','),
-          search_term
+          withTag: tags.join(','),
+          searchTerm
         }
       })
     }

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -75,8 +75,8 @@ export default {
         version,
         starts_with: lang + '/events/',
         sort_by: 'sort_by_date:desc',
-        withTag: this.checkedTags,
-        searchTerm
+        with_tag: this.checkedTags,
+        search_term: searchTerm
       })
       this.events = events.data.stories
     } catch (e) {

--- a/pages/search.vue
+++ b/pages/search.vue
@@ -41,9 +41,6 @@
 </template>
 
 <script>
-/* eslint-disable no-console */
-/* eslint-disable camelcase */
-
 import eventPreviewSkeleton from '@/components/event-preview/event-preview-skeleton'
 import eventPreview from '@/components/event-preview/event-preview'
 
@@ -83,6 +80,7 @@ export default {
       })
       this.events = events.data.stories
     } catch (e) {
+      // eslint-disable-next-line no-console
       console.error(e)
     }
   },


### PR DESCRIPTION
### PR check list
<!-- ✍️
- [x] Please check using "x" if your PR fulfills the following requirements -->
- [x] The title of the PR is formatted following [conventional commits](https://www.conventionalcommits.org/) format <!-- 
  ** PR/commit prefix reminder:
    build: Changes that affect the build system or external dependencies (eg. scopes: npm, netlify, cypress)
    ci: Changes to our CI configuration files and scripts (eg. scopes: github, netlify)
    docs: Documentation only changes
    feat: A new feature
    fix: A bug fix
    perf: A code change that improves performance
    refactor: A code change that neither fixes a bug nor adds a feature
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    test: Adding missing tests or correcting existing tests -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Functionality has been verified and is ready to be code reviewed


### Relevant issues

<!-- ✍️ Tag any relevant issues or links for context
  Issues can be linked by issue number ex. #123
  If merging this issue completes the issue, use the "Closes" keyword to automatically close the parent issue ex. Closes #123
  Otherwise, paste a link to any relevant task details or remove this section entirely.
-->

## What is the current behavior?

<!-- ✍️ Describe and provide screenshots/video/gif when applicable or remove this section entirely -->

We do have a lot of `eslint-disable` throughout the code base, some unnecessary, and some that can be easily fixed. 

## What is the new behavior?

<!-- ✍️ Describe or provide screenshots/video/gif of the changes introduced -->
`eslint-disable` instructions have been minimized to stay aligned on the good practices eslinter is there for. 

Also as a bonus, I added: 
- load current querystring `searchTerm` into the search box on refresh
- clear the querystring `searchTerm` when we click on the search box "clear" / `x` button

## Other information

<!-- ✍️ Any additional context into the problem or why you solved it in the way you did -->

It's important to test the search and tags filtering to make sure it works as intended. Tested a bit and it looks good rn. 

**Does this PR introduce a breaking change?** 
<!-- ✍️ Yes/No -->
No
<!-- ✍️ If yes, please describe the impact and migration path -->
