### PR TITLE
fix: add back mobile nav left white background

### DIFF
--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -75,6 +75,7 @@ html {
   display: inherit;
   left: 0;
   transition: 0.3s ease-out;
+  @apply left-0 bg-mtl-white;
 }
 
 @media (min-width: 1024px) {


### PR DESCRIPTION
### PR check list
- [x] The title of the PR is formatted following [conventional commits](https://www.conventionalcommits.org/) format 
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Functionality has been verified and is ready to be code reviewed

### Relevant issues
Closes #185 

## What is the current behavior?

no background mobile nav-left

## What is the new behavior?

adding the background on nav-left white


**Does this PR introduce a breaking change?** 
<!-- ✍️ Yes/No -->
no
<!-- ✍️ If yes, please describe the impact and migration path -->
