### PR TITLE
feat: add translation, pluralization and auto-hiding of speaker title 

### DIFF
--- a/configs/i18n.js
+++ b/configs/i18n.js
@@ -14,7 +14,8 @@ module.exports = {
         home: 'Home',
         more: 'More',
         register: 'Register',
-        slides: 'View slides'
+        slides: 'View slides',
+        speaker: 'Speaker | Speakers'
       },
       fr: {
         archives: 'Archives',
@@ -23,7 +24,8 @@ module.exports = {
         home: 'Accueil',
         more: "Plus d'infos",
         register: "S'inscrire",
-        slides: 'Voir les diapositives'
+        slides: 'Voir les diapositives',
+        speaker: 'Conférencier | Conférenciers'
       }
     }
   },

--- a/configs/i18n.js
+++ b/configs/i18n.js
@@ -15,7 +15,8 @@ module.exports = {
         more: 'More',
         register: 'Register',
         slides: 'View slides',
-        speaker: 'Speaker | Speakers'
+        'speaker-m': 'Speaker | Speakers',
+        'speaker-f': 'Speaker | Speakers'
       },
       fr: {
         archives: 'Archives',
@@ -25,7 +26,8 @@ module.exports = {
         more: "Plus d'infos",
         register: "S'inscrire",
         slides: 'Voir les diapositives',
-        speaker: 'Conférencier | Conférenciers'
+        'speaker-m': 'Conférencier | Conférenciers',
+        'speaker-f': 'Conférencière | Conférencières'
       }
     }
   },

--- a/pages/events/_eventId.vue
+++ b/pages/events/_eventId.vue
@@ -19,7 +19,7 @@
       <text-description :text="story.content.description" class="mb-10" />
       <template v-if="story.content.speakers.length">
         <h2 class="mb-4 font-bold">
-          {{ $tc('speaker', story.content.speakers.length) }}
+          {{ $tc(genderedSpeaker, story.content.speakers.length) }}
         </h2>
         <div v-for="speaker in story.content.speakers" :key="speaker._uid">
           <speakerCard :speaker="speaker" />
@@ -98,6 +98,12 @@ export default {
     }
   },
   computed: {
+    genderedSpeaker() {
+      console.warn(this.story.content.speakers)
+      return this.story.content.speakers.every((s) => s.gender === 'f')
+        ? 'speaker-f'
+        : 'speaker-m'
+    },
     getImages() {
       const images = []
       this.story.content.gallery.forEach((img) => {

--- a/pages/events/_eventId.vue
+++ b/pages/events/_eventId.vue
@@ -17,7 +17,9 @@
     </template>
     <div>
       <text-description :text="story.content.description" class="mb-10" />
-      <h2 class="mb-4 font-bold">Speakers:</h2>
+      <h2 class="mb-4 font-bold">
+        {{ $tc('speaker', story.content.speakers.length) }}
+      </h2>
       <div v-for="speaker in story.content.speakers" :key="speaker._uid">
         <speakerCard :speaker="speaker" />
       </div>

--- a/pages/events/_eventId.vue
+++ b/pages/events/_eventId.vue
@@ -17,12 +17,14 @@
     </template>
     <div>
       <text-description :text="story.content.description" class="mb-10" />
-      <h2 class="mb-4 font-bold">
-        {{ $tc('speaker', story.content.speakers.length) }}
-      </h2>
-      <div v-for="speaker in story.content.speakers" :key="speaker._uid">
-        <speakerCard :speaker="speaker" />
-      </div>
+      <template v-if="story.content.speakers.length">
+        <h2 class="mb-4 font-bold">
+          {{ $tc('speaker', story.content.speakers.length) }}
+        </h2>
+        <div v-for="speaker in story.content.speakers" :key="speaker._uid">
+          <speakerCard :speaker="speaker" />
+        </div>
+      </template>
       <carousel v-if="getImages.length > 0">
         <carousel-slide v-for="(image, index) in getImages" :key="index">
           <img :src="image" alt="" class="w-full" />

--- a/pages/events/_eventId.vue
+++ b/pages/events/_eventId.vue
@@ -99,7 +99,6 @@ export default {
   },
   computed: {
     genderedSpeaker() {
-      console.warn(this.story.content.speakers)
       return this.story.content.speakers.every((s) => s.gender === 'f')
         ? 'speaker-f'
         : 'speaker-m'


### PR DESCRIPTION
### PR check list
<!-- ✍️
- [x] Please check using "x" if your PR fulfills the following requirements -->
- [x] The title of the PR is formatted following [conventional commits](https://www.conventionalcommits.org/) format <!-- 
  ** PR/commit prefix reminder:
    build: Changes that affect the build system or external dependencies (eg. scopes: npm, netlify, cypress)
    ci: Changes to our CI configuration files and scripts (eg. scopes: github, netlify)
    docs: Documentation only changes
    feat: A new feature
    fix: A bug fix
    perf: A code change that improves performance
    refactor: A code change that neither fixes a bug nor adds a feature
    style: Changes that do not affect the meaning of the code (white-space, formatting, etc)
    test: Adding missing tests or correcting existing tests -->
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Functionality has been verified and is ready to be code reviewed


### Relevant issues

<!-- ✍️ Tag any relevant issues or links for context
  Issues can be linked by issue number ex. #123
  If merging this issue completes the issue, use the "Closes" keyword to automatically close the parent issue ex. Closes #123
  Otherwise, paste a link to any relevant task details or remove this section entirely.
-->

N/A

## What is the current behavior?

<!-- ✍️ Describe and provide screenshots/video/gif when applicable or remove this section entirely -->

The work speaker is not translated and is always plural: 
eg.: https://vuemontreal.org/en/events/014-vue-3-0-composition-api-online-event

<img src=https://user-images.githubusercontent.com/1448836/89138855-ec5b0a00-d50a-11ea-8776-c532fe3604f2.png width="75%">

The word speakers is displayed when there is no speakers assigned to an event: 

<img src=https://user-images.githubusercontent.com/1448836/89139134-bf5b2700-d50b-11ea-981d-5657e624ad96.png width="75%">


## What is the new behavior?

<!-- ✍️ Describe or provide screenshots/video/gif of the changes introduced -->

The word _speaker_ is translated and pluralized as needed: 

<img src=https://user-images.githubusercontent.com/1448836/89138934-3643f000-d50b-11ea-8114-a56345d33be8.png width="75%">

https://deploy-preview-209--vuemontreal.netlify.app/fr/events/013-special-nuxtjs-team-guests-static-sites-seo

\* In French, the word will also be feminine if all the speakers are feminine for a given event. 


<img src=https://user-images.githubusercontent.com/1448836/89138964-4e1b7400-d50b-11ea-807d-df0b5fcc9f75.png width="75%">

https://deploy-preview-209--vuemontreal.netlify.app/en/events/014-vue-3-0-composition-api-online-event

Also, the speaker title will not appear when there is no speakers:

<img src=https://user-images.githubusercontent.com/1448836/89139100-a9e5fd00-d50b-11ea-800c-1a30e8e66a10.png width="75%">

https://deploy-preview-209--vuemontreal.netlify.app/fr/events/word-vue-summit-external-online-event


## Other information

<!-- ✍️ Any additional context into the problem or why you solved it in the way you did -->


**Does this PR introduce a breaking change?** 
<!-- ✍️ Yes/No -->
No
<!-- ✍️ If yes, please describe the impact and migration path -->
